### PR TITLE
Allow comments in txt file list read by Reader::LoadPaths()

### DIFF
--- a/src/Reader/Reader.cc
+++ b/src/Reader/Reader.cc
@@ -45,13 +45,20 @@ namespace DATOR {
     else if (!fn.substr(fn.size()-4).compare(".txt")) {
       std::ifstream infile(fn);
       if (!infile.is_open()) { std::cerr << fn << " not found!" << std::endl; return -1; }
-
+      
+      std::string tline;
       int indx;
       std::string path;
 
       runPaths.clear();
       runNos.clear();
-      while (infile >> indx >> path) {
+      while (std::getline(infile, tline)) {
+        if(tline[0] == "#"[0]){
+          continue;
+        }
+        std::stringstream st(tline);
+        st >> indx >> path;
+
         runPaths.push_back(path);
         runNos.push_back(indx);
         if (!path.substr(path.size()-7).compare(".dat.gz")) {


### PR DESCRIPTION
Change Reader::LoadPaths to use an intermediate string object with a stringstream to break apart run numbers and input files specified in .txt files. This also allows commenting out individual lines with "#" at the beginning by comparing the intermediate string object.

Comments at the end of the file name are supported by default because of the way the intermediate string is processed.